### PR TITLE
Fix QR lookup and submenu index bug

### DIFF
--- a/src/app/MainApp.jsx
+++ b/src/app/MainApp.jsx
@@ -93,7 +93,8 @@ export default function MainApp(props) {
   const [isSectionMenuOpen, setSectionMenuOpen] = useState(false);
 
   //finzione per gestire la visibilità del SectionMenu
-  const toggleSectionMenu = () => {
+  const toggleSectionMenu = (index) => {
+    setSectionIndex(index);
     setSectionMenuOpen(true);
   };
 
@@ -351,6 +352,7 @@ function MenuDiv({
                         section.onClick
                           ? section.onClick()
                           : navigate(section.path);
+                        toggleSectionMenu(index);
                       }}
                       className="flex flex-row items-center justify-start"
                     >
@@ -361,7 +363,7 @@ function MenuDiv({
             )}
 
             {isSectionMenuOpen && (
-              <SectionMenu data={menuSections[index].data} />
+              <SectionMenu data={menuSections[isSectionIndex].data} />
             )}
           </div>
         </div>

--- a/src/app/components/InfoDiv.jsx
+++ b/src/app/components/InfoDiv.jsx
@@ -39,7 +39,7 @@ export function InfoDiv({ isBottomDivOpen, selected, handlers }) {
   function onResult(obj) {
     if (obj) {
       const bicicletta = JSON.parse(obj);
-      let bici = state.bici.find((b) => (b.id = bicicletta.biciId));
+      let bici = state.bici.find((b) => b.id === bicicletta.biciId);
       handlers.setSelected(bici);
       setShowQrDialog(false);
       handlers.showBottomDiv();


### PR DESCRIPTION
## Summary
- fix equality check when looking up bike from QR code
- track clicked menu item to show SectionMenu

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b1c19de4833285cb3af599826341